### PR TITLE
Add Go daemon to notify about nearby aircraft

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,36 @@
+version: 2
+project_name: whats-flying-over-me
+
+builds:
+  - id: wfo
+    main: ./cmd/whats-flying-over-me
+    binary: whats-flying-over-me
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - builds:
+      - wfo
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+
+dockers:
+  - ids:
+      - wfo
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}"
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    goos: linux
+    goarch: amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.19
+RUN apk --no-cache add ca-certificates
+COPY whats-flying-over-me /usr/local/bin/whats-flying-over-me
+ENTRYPOINT ["/usr/local/bin/whats-flying-over-me"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: fmt vet lint sec test build all
+
+fmt:
+	go fmt ./...
+
+vet:
+	go vet ./...
+
+lint:
+	golangci-lint run ./...
+
+sec:
+	gosec ./...
+
+test:
+	go test ./...
+
+build:
+	go build ./...
+
+all: fmt vet lint sec test build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,85 @@
 # whats-flying-over-me
+
 Be alerted to what airplane is flying overhead using a local piaware
+
+## Build and run
+
+`whats-flying-over-me` is a Go daemon that periodically scrapes a piaware JSON feed and sends notifications when aircraft are within a configured radius and altitude of a base location.
+
+### Configuration
+
+Settings may be provided via a JSON config file, environment variables, or command line flags. Precedence is command line > environment > config file > defaults.
+
+#### Config file
+
+By default the daemon reads `config.json` in the working directory (override with the `-config` flag or `WFO_CONFIG` environment variable):
+
+```json
+{
+  "ScrapeInterval": "1m",
+  "RadiusKm": 25,
+  "AltitudeMax": 10000,
+  "BaseLat": 37.6213,
+  "BaseLon": -122.3790,
+  "DataURL": "http://localhost:8080/data/aircraft.json",
+  "Notifier": {
+    "Method": "email",
+    "Email": {
+      "SMTPServer": "smtp.example.com",
+      "SMTPPort": 587,
+      "Username": "user",
+      "Password": "pass",
+      "From": "you@example.com",
+      "To": "notify@example.com"
+    }
+  }
+}
+```
+
+#### Environment variables
+
+Each setting also has an environment variable (`WFO_*`) counterpart:
+
+- `WFO_INTERVAL`
+- `WFO_RADIUS_KM`
+- `WFO_ALTITUDE_MAX`
+- `WFO_BASE_LAT`
+- `WFO_BASE_LON`
+- `WFO_DATA_URL`
+- `WFO_NOTIFY`
+- `WFO_SMTP_SERVER`
+- `WFO_SMTP_PORT`
+- `WFO_SMTP_USER`
+- `WFO_SMTP_PASS`
+- `WFO_EMAIL_FROM`
+- `WFO_EMAIL_TO`
+
+#### Command line flags
+
+Command line flags override all other sources and match the names above:
+
+- `-interval` scrape interval (e.g. `30s`, `1m`)
+- `-radius` radius of interest in kilometers
+- `-altitude` altitude ceiling in feet
+- `-lat` base latitude
+- `-lon` base longitude
+- `-url` data retrieval URL
+- `-notify` notification method (`email`)
+- `-smtp-server` SMTP server for email notifications
+- `-smtp-port` SMTP port
+- `-smtp-user` SMTP username
+- `-smtp-pass` SMTP password
+- `-email-from` sender address
+- `-email-to` recipient address
+
+### Example
+
+```
+go run ./cmd/whats-flying-over-me \
+  -lat 37.6213 -lon -122.3790 \
+  -radius 20 -altitude 10000 \
+  -smtp-server smtp.example.com -smtp-port 587 \
+  -smtp-user user -smtp-pass pass \
+  -email-from you@example.com -email-to notify@example.com
+```
+

--- a/cmd/whats-flying-over-me/main.go
+++ b/cmd/whats-flying-over-me/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/example/whats-flying-over-me/internal/config"
+	"github.com/example/whats-flying-over-me/internal/logger"
+	"github.com/example/whats-flying-over-me/internal/notifier"
+	"github.com/example/whats-flying-over-me/internal/piaware"
+)
+
+func main() {
+	cfg := config.Load()
+
+	n, err := notifier.New(cfg.Notifier)
+	if err != nil {
+		logger.Critical("failed to initialize notifier", map[string]interface{}{"error": err.Error()})
+		return
+	}
+
+	ticker := time.NewTicker(cfg.ScrapeInterval)
+	defer ticker.Stop()
+	notified := make(map[string]bool)
+
+	for {
+		if err := check(cfg, n, notified); err != nil {
+			logger.Err("check failed", map[string]interface{}{"error": err.Error()})
+		}
+		<-ticker.C
+	}
+}
+
+func check(cfg config.Config, n notifier.Notifier, notified map[string]bool) error {
+	aircraft, err := piaware.Fetch(cfg.DataURL)
+	if err != nil {
+		return err
+	}
+	nearby := piaware.FilterAircraft(aircraft, cfg.BaseLat, cfg.BaseLon, cfg.RadiusKm, cfg.AltitudeMax)
+
+	for _, a := range nearby {
+		if notified[a.Hex] {
+			continue
+		}
+		subject := fmt.Sprintf("Aircraft %s nearby", a.Hex)
+		body := fmt.Sprintf("Flight: %s\nAltitude: %d ft\nDistance: %.1f km", a.Flight, a.AltBaro, a.DistanceKm)
+		if err := n.Notify(subject, body); err != nil {
+			logger.Err("notification failed", map[string]interface{}{"hex": a.Hex, "error": err.Error()})
+			continue
+		}
+		notified[a.Hex] = true
+		logger.Warn("notified", map[string]interface{}{"hex": a.Hex, "flight": a.Flight})
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/whats-flying-over-me
+
+go 1.24.3

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,205 @@
+package config
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"strconv"
+	"time"
+)
+
+// Config holds the application configuration.
+type Config struct {
+	ScrapeInterval time.Duration
+	RadiusKm       float64
+	AltitudeMax    int
+	BaseLat        float64
+	BaseLon        float64
+	DataURL        string
+	Notifier       NotifierConfig
+}
+
+// NotifierConfig holds notifier settings.
+type NotifierConfig struct {
+	Method string
+	Email  EmailConfig
+}
+
+// EmailConfig holds email notifier settings.
+type EmailConfig struct {
+	SMTPServer string
+	SMTPPort   int
+	Username   string
+	Password   string
+	From       string
+	To         string
+}
+
+const (
+	envConfigFile = "WFO_CONFIG"
+	envInterval   = "WFO_INTERVAL"
+	envRadius     = "WFO_RADIUS_KM"
+	envAltitude   = "WFO_ALTITUDE_MAX"
+	envBaseLat    = "WFO_BASE_LAT"
+	envBaseLon    = "WFO_BASE_LON"
+	envDataURL    = "WFO_DATA_URL"
+	envNotify     = "WFO_NOTIFY"
+	envSMTPServer = "WFO_SMTP_SERVER"
+	envSMTPPort   = "WFO_SMTP_PORT"
+	envSMTPUser   = "WFO_SMTP_USER"
+	envSMTPPass   = "WFO_SMTP_PASS" // #nosec G101
+	envEmailFrom  = "WFO_EMAIL_FROM"
+	envEmailTo    = "WFO_EMAIL_TO"
+)
+
+// Load reads configuration from config file, environment variables and command line flags
+// in order of increasing precedence.
+func Load() Config {
+	// Defaults
+	cfg := Config{
+		ScrapeInterval: time.Minute,
+		RadiusKm:       25.0,
+		AltitudeMax:    10000,
+		DataURL:        "http://localhost:8080/data/aircraft.json",
+		Notifier: NotifierConfig{
+			Method: "email",
+			Email:  EmailConfig{SMTPPort: 587},
+		},
+	}
+
+	// Command line flags
+	configPath := flag.String("config", "", "path to config file")
+
+	interval := flag.Duration("interval", 0, "scrape interval")
+	radius := flag.Float64("radius", 0, "radius of interest in km")
+	altitude := flag.Int("altitude", 0, "altitude ceiling in feet")
+	lat := flag.Float64("lat", 0, "base latitude")
+	lon := flag.Float64("lon", 0, "base longitude")
+	dataURL := flag.String("url", "", "piaware data URL")
+	notify := flag.String("notify", "", "notification method")
+
+	smtpServer := flag.String("smtp-server", "", "SMTP server")
+	smtpPort := flag.Int("smtp-port", 0, "SMTP port")
+	smtpUser := flag.String("smtp-user", "", "SMTP username")
+	smtpPass := flag.String("smtp-pass", "", "SMTP password")
+	emailFrom := flag.String("email-from", "", "email sender")
+	emailTo := flag.String("email-to", "", "email recipient")
+
+	flag.Parse()
+
+	setFlags := map[string]bool{}
+	flag.CommandLine.Visit(func(f *flag.Flag) { setFlags[f.Name] = true })
+
+	// Config file
+	path := *configPath
+	if path == "" {
+		path = getenv(envConfigFile, "config.json")
+	}
+	// #nosec G304 -- path is controlled via trusted config
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, &cfg)
+	}
+
+	// Environment variables
+	if v, ok := os.LookupEnv(envInterval); ok {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.ScrapeInterval = d
+		}
+	}
+	if v, ok := os.LookupEnv(envRadius); ok {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			cfg.RadiusKm = f
+		}
+	}
+	if v, ok := os.LookupEnv(envAltitude); ok {
+		if i, err := strconv.Atoi(v); err == nil {
+			cfg.AltitudeMax = i
+		}
+	}
+	if v, ok := os.LookupEnv(envBaseLat); ok {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			cfg.BaseLat = f
+		}
+	}
+	if v, ok := os.LookupEnv(envBaseLon); ok {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			cfg.BaseLon = f
+		}
+	}
+	if v, ok := os.LookupEnv(envDataURL); ok {
+		cfg.DataURL = v
+	}
+	if v, ok := os.LookupEnv(envNotify); ok {
+		cfg.Notifier.Method = v
+	}
+	if v, ok := os.LookupEnv(envSMTPServer); ok {
+		cfg.Notifier.Email.SMTPServer = v
+	}
+	if v, ok := os.LookupEnv(envSMTPPort); ok {
+		if i, err := strconv.Atoi(v); err == nil {
+			cfg.Notifier.Email.SMTPPort = i
+		}
+	}
+	if v, ok := os.LookupEnv(envSMTPUser); ok {
+		cfg.Notifier.Email.Username = v
+	}
+	if v, ok := os.LookupEnv(envSMTPPass); ok {
+		cfg.Notifier.Email.Password = v
+	}
+	if v, ok := os.LookupEnv(envEmailFrom); ok {
+		cfg.Notifier.Email.From = v
+	}
+	if v, ok := os.LookupEnv(envEmailTo); ok {
+		cfg.Notifier.Email.To = v
+	}
+
+	// Command line overrides
+	if setFlags["interval"] {
+		cfg.ScrapeInterval = *interval
+	}
+	if setFlags["radius"] {
+		cfg.RadiusKm = *radius
+	}
+	if setFlags["altitude"] {
+		cfg.AltitudeMax = *altitude
+	}
+	if setFlags["lat"] {
+		cfg.BaseLat = *lat
+	}
+	if setFlags["lon"] {
+		cfg.BaseLon = *lon
+	}
+	if setFlags["url"] {
+		cfg.DataURL = *dataURL
+	}
+	if setFlags["notify"] {
+		cfg.Notifier.Method = *notify
+	}
+	if setFlags["smtp-server"] {
+		cfg.Notifier.Email.SMTPServer = *smtpServer
+	}
+	if setFlags["smtp-port"] {
+		cfg.Notifier.Email.SMTPPort = *smtpPort
+	}
+	if setFlags["smtp-user"] {
+		cfg.Notifier.Email.Username = *smtpUser
+	}
+	if setFlags["smtp-pass"] {
+		cfg.Notifier.Email.Password = *smtpPass
+	}
+	if setFlags["email-from"] {
+		cfg.Notifier.Email.From = *emailFrom
+	}
+	if setFlags["email-to"] {
+		cfg.Notifier.Email.To = *emailTo
+	}
+
+	return cfg
+}
+
+func getenv(key, def string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return def
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"flag"
+	"os"
+	"testing"
+	"time"
+)
+
+// helper to reset environment and flags
+func reset() {
+	os.Clearenv()
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	os.Args = []string{os.Args[0]}
+}
+
+func TestLoadPrecedence(t *testing.T) {
+	reset()
+	// create temp config file
+	cfgFile, err := os.CreateTemp(t.TempDir(), "cfg*.json")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	if _, err := cfgFile.WriteString(`{"RadiusKm":10}`); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := cfgFile.Close(); err != nil {
+		t.Fatalf("close config: %v", err)
+	}
+
+	if err := os.Setenv("WFO_CONFIG", cfgFile.Name()); err != nil {
+		t.Fatalf("set env: %v", err)
+	}
+	if err := os.Setenv("WFO_RADIUS_KM", "20"); err != nil {
+		t.Fatalf("set env: %v", err)
+	}
+
+	// set command line flag
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	os.Args = []string{os.Args[0], "-radius", "30"}
+
+	cfg := Load()
+	if cfg.RadiusKm != 30 {
+		t.Fatalf("expected radius 30, got %v", cfg.RadiusKm)
+	}
+}
+
+func TestLoadDefaults(t *testing.T) {
+	reset()
+	cfg := Load()
+	if cfg.ScrapeInterval != time.Minute {
+		t.Errorf("expected default interval %v, got %v", time.Minute, cfg.ScrapeInterval)
+	}
+	if cfg.RadiusKm != 25 {
+		t.Errorf("expected default radius 25, got %v", cfg.RadiusKm)
+	}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,51 @@
+package logger
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+type Level string
+
+const (
+	LevelWarn     Level = "WARN"
+	LevelErr      Level = "ERR"
+	LevelCritical Level = "CRITICAL"
+)
+
+// logEntry represents a single log entry.
+type logEntry struct {
+	Timestamp string                 `json:"timestamp"`
+	Level     Level                  `json:"level"`
+	Message   string                 `json:"message"`
+	Fields    map[string]interface{} `json:"fields,omitempty"`
+}
+
+func log(level Level, msg string, fields map[string]interface{}) {
+	entry := logEntry{
+		Timestamp: time.Now().Format(time.RFC3339),
+		Level:     level,
+		Message:   msg,
+		Fields:    fields,
+	}
+	enc := json.NewEncoder(os.Stdout)
+	if err := enc.Encode(entry); err != nil {
+		if _, err2 := fmt.Fprintf(os.Stdout, "{\"timestamp\":%q,\"level\":%q,\"message\":%q,\"error\":%q}\n", entry.Timestamp, level, msg, err); err2 != nil {
+			_ = err2
+		}
+	}
+}
+
+func Warn(msg string, fields map[string]interface{}) {
+	log(LevelWarn, msg, fields)
+}
+
+func Err(msg string, fields map[string]interface{}) {
+	log(LevelErr, msg, fields)
+}
+
+func Critical(msg string, fields map[string]interface{}) {
+	log(LevelCritical, msg, fields)
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,46 @@
+package logger
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+)
+
+func capture(t *testing.T, f func()) map[string]interface{} {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	f()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+	os.Stdout = old
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return m
+}
+
+func TestLevels(t *testing.T) {
+	m := capture(t, func() { Warn("warn", nil) })
+	if m["level"] != string(LevelWarn) {
+		t.Errorf("expected WARN level, got %v", m["level"])
+	}
+	m = capture(t, func() { Err("err", nil) })
+	if m["level"] != string(LevelErr) {
+		t.Errorf("expected ERR level, got %v", m["level"])
+	}
+	m = capture(t, func() { Critical("crit", nil) })
+	if m["level"] != string(LevelCritical) {
+		t.Errorf("expected CRITICAL level, got %v", m["level"])
+	}
+}

--- a/internal/notifier/email.go
+++ b/internal/notifier/email.go
@@ -1,0 +1,30 @@
+package notifier
+
+import (
+	"fmt"
+	"net/smtp"
+
+	"github.com/example/whats-flying-over-me/internal/config"
+)
+
+// Email implements Notifier using SMTP.
+type Email struct {
+	cfg config.EmailConfig
+}
+
+// NewEmail creates a new Email notifier.
+func NewEmail(cfg config.EmailConfig) *Email {
+	return &Email{cfg: cfg}
+}
+
+// Notify sends an email notification.
+func (e *Email) Notify(subject, body string) error {
+	auth := smtp.PlainAuth("", e.cfg.Username, e.cfg.Password, e.cfg.SMTPServer)
+	addr := fmt.Sprintf("%s:%d", e.cfg.SMTPServer, e.cfg.SMTPPort)
+
+	msg := []byte("To: " + e.cfg.To + "\r\n" +
+		"Subject: " + subject + "\r\n" +
+		"\r\n" + body + "\r\n")
+
+	return smtp.SendMail(addr, auth, e.cfg.From, []string{e.cfg.To}, msg)
+}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -1,0 +1,22 @@
+package notifier
+
+import (
+	"fmt"
+
+	"github.com/example/whats-flying-over-me/internal/config"
+)
+
+// Notifier defines a mechanism for sending notifications.
+type Notifier interface {
+	Notify(subject, body string) error
+}
+
+// New creates a notifier based on the configuration.
+func New(cfg config.NotifierConfig) (Notifier, error) {
+	switch cfg.Method {
+	case "email":
+		return NewEmail(cfg.Email), nil
+	default:
+		return nil, fmt.Errorf("unknown notifier method: %s", cfg.Method)
+	}
+}

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -1,0 +1,23 @@
+package notifier
+
+import (
+	"testing"
+
+	"github.com/example/whats-flying-over-me/internal/config"
+)
+
+func TestNewEmail(t *testing.T) {
+	n, err := New(config.NotifierConfig{Method: "email"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := n.(*Email); !ok {
+		t.Fatalf("expected *Email, got %T", n)
+	}
+}
+
+func TestNewUnknown(t *testing.T) {
+	if _, err := New(config.NotifierConfig{Method: "sms"}); err == nil {
+		t.Fatal("expected error for unknown notifier")
+	}
+}

--- a/internal/piaware/piaware.go
+++ b/internal/piaware/piaware.go
@@ -1,0 +1,77 @@
+package piaware
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"time"
+)
+
+// Aircraft represents an aircraft entry from piaware.
+type Aircraft struct {
+	Hex     string  `json:"hex"`
+	Flight  string  `json:"flight"`
+	Lat     float64 `json:"lat"`
+	Lon     float64 `json:"lon"`
+	AltBaro int     `json:"alt_baro"`
+}
+
+// Data represents the piaware aircraft JSON response.
+type Data struct {
+	Now      int64      `json:"now"`
+	Aircraft []Aircraft `json:"aircraft"`
+}
+
+// Fetch retrieves aircraft data from the given URL.
+func Fetch(url string) ([]Aircraft, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unexpected status %s: %s", resp.Status, string(b))
+	}
+	var data Data
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+	return data.Aircraft, nil
+}
+
+// NearbyAircraft is an aircraft with associated distance from the base.
+type NearbyAircraft struct {
+	Aircraft
+	DistanceKm float64
+}
+
+// FilterAircraft returns aircraft within the radius (km) and below altitude.
+func FilterAircraft(aircraft []Aircraft, baseLat, baseLon, radiusKm float64, altMax int) []NearbyAircraft {
+	var result []NearbyAircraft
+	for _, a := range aircraft {
+		if a.Lat == 0 && a.Lon == 0 {
+			continue
+		}
+		dist := distance(baseLat, baseLon, a.Lat, a.Lon)
+		if dist <= radiusKm && a.AltBaro <= altMax {
+			result = append(result, NearbyAircraft{Aircraft: a, DistanceKm: dist})
+		}
+	}
+	return result
+}
+
+// distance calculates the haversine distance in kilometers between two points.
+func distance(lat1, lon1, lat2, lon2 float64) float64 {
+	const R = 6371.0 // Earth radius in kilometers
+	dLat := (lat2 - lat1) * math.Pi / 180
+	dLon := (lon2 - lon1) * math.Pi / 180
+	a := math.Sin(dLat/2)*math.Sin(dLat/2) + math.Cos(lat1*math.Pi/180)*math.Cos(lat2*math.Pi/180)*math.Sin(dLon/2)*math.Sin(dLon/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	return R * c
+}

--- a/internal/piaware/piaware_test.go
+++ b/internal/piaware/piaware_test.go
@@ -1,0 +1,51 @@
+package piaware
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDistance(t *testing.T) {
+	if d := distance(0, 0, 0, 0); d != 0 {
+		t.Fatalf("expected 0 distance, got %v", d)
+	}
+}
+
+func TestFilterAircraft(t *testing.T) {
+	aircraft := []Aircraft{
+		{Hex: "1", Lat: 0.1, Lon: 0.1, AltBaro: 1000},
+		{Hex: "2", Lat: 50, Lon: 50, AltBaro: 2000},
+	}
+	res := FilterAircraft(aircraft, 0, 0, 1000, 1500)
+	if len(res) != 1 || res[0].Hex != "1" {
+		t.Fatalf("unexpected filter result: %+v", res)
+	}
+}
+
+func TestFetch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.WriteString(w, `{"now":1,"aircraft":[{"hex":"abc","flight":"TEST","lat":1,"lon":2,"alt_baro":300}]}`); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}))
+	defer srv.Close()
+	ac, err := Fetch(srv.URL)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(ac) != 1 || ac[0].Hex != "abc" {
+		t.Fatalf("unexpected fetch result: %+v", ac)
+	}
+}
+
+func TestFetchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	if _, err := Fetch(srv.URL); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests covering config loading, logging, notifier selection and piaware interactions
- introduce Makefile with targets for fmt, vet, lint, security scan, tests and build
- tighten error handling in logger and piaware packages
- add Dependabot config for weekly dependency checks
- add release workflow to build and publish binaries on semver tags
- switch release workflow to GoReleaser with cross-platform and container builds

## Testing
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `gosec ./...`
- `go build ./...`
- `go test ./...`
- `./goreleaser check` *(fails: configuration is invalid: no remote configured to list refs from)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bf5018bc8321b78bb9f15bfd37bf