### PR TITLE
chore: add .tool-versions file and rename 'all' target to 'check' in …

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,5 @@
+golang 1.24.4
+gosec 2.22.7
+golangci-lint 2.3.0
+staticcheck 0.6.0
+govulncheck 1.1.4

--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ test:
 build:
 	go build ./...
 
-all: fmt vet lint sec test build
+check: fmt vet lint sec test build


### PR DESCRIPTION
…Makefile

- Introduced a new .tool-versions file specifying versions for golang, gosec, golangci-lint, staticcheck, and govulncheck.
- Renamed the 'all' target in the Makefile to 'check' for clarity.